### PR TITLE
replace_redmine_login feature correction

### DIFF
--- a/lib/redmine_saml/patches/account_controller_patch.rb
+++ b/lib/redmine_saml/patches/account_controller_patch.rb
@@ -24,7 +24,7 @@ module RedmineSaml
         end
 
         def login_with_saml_redirect
-          render_404
+          redirect_to ::RedmineSaml.configured_saml['idp_sso_service_url']
         end
 
         def login_with_saml_callback


### PR DESCRIPTION
replace_redmine_login feature didn't work :
- Always ending on a 404 page
- This is because only post request begining with /auth are capture by omniauth saml
- Redirect to configured sso login page instead of rendering 404 page